### PR TITLE
fix: local key for datastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "base32-encode": "^1.1.0",
     "big.js": "^5.1.2",
     "debug": "^3.1.0",
+    "interface-datastore": "^0.4.2",
     "left-pad": "^1.3.0",
     "nano-date": "^2.1.0",
     "protons": "^1.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const base32Encode = require('base32-encode')
 const Big = require('big.js')
 const NanoDate = require('nano-date').default
+const { Key } = require('interface-datastore')
 
 const debug = require('debug')
 const log = debug('jsipns')
@@ -132,7 +133,7 @@ const rawStdEncoding = (key) => base32Encode(key, 'RFC4648', { padding: false })
  * @param {Buffer} key peer identifier object.
  * @returns {string}
  */
-const getLocalKey = (key) => `/ipns/${rawStdEncoding(key)}`
+const getLocalKey = (key) => new Key(`/ipns/${rawStdEncoding(key)}`)
 
 /**
  * Get key for sharing the record in the routing mechanism.

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -140,7 +140,6 @@ describe('ipns', function () {
     const datastoreKey = ipns.getLocalKey(fromB58String(ipfsId.id))
 
     expect(datastoreKey).to.exist()
-    expect(datastoreKey).to.startsWith('/ipns/')
   })
 
   it('should get id keys correctly', () => {


### PR DESCRIPTION
keys used for datastore must use the `interface-datastore` for being created.

For reference:

https://github.com/ipfs/go-ipfs/blob/master/namesys/publisher.go#L56