### PR TITLE
Make small fix to license text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,4 +184,4 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 ## License
 
-Copyright (c) Protocol Labs, Inc. under the **MIT**. See [MIT](./LICENSE) for details.
+Copyright (c) Protocol Labs, Inc. under the **MIT License**. See [LICENSE file](./LICENSE) for details.


### PR DESCRIPTION
This is just a small tweak to the text of the licensing section in the README. It should help it read a little bit clearer.