### PR TITLE
feat: add records validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+docs/
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Contains an object with `validate (marshalledData, peerId, callback)` and `selec
 
 The `validate` function aims to verify if an IPNS record is valid. First the record is unmarshalled, then the public key is obtained and finally the record is validated (signature and validity are verified).
 
-The `select` function is responsible for deciding which ipns record is the best (newer) between two records. Both records are unmarshalled and their sequece numbers are compared. If the first record provided is the newer, the operation result will be `0`, otherwise the operation result will be `1`.
+The `select` function is responsible for deciding which ipns record is the best (newer) between two records. Both records are unmarshalled and their sequence numbers are compared. If the first record provided is the newer, the operation result will be `0`, otherwise the operation result will be `1`.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ const data = ipns.unmarshal(storedData)
 
 Returns the entry data structure after being serialized.
 
+#### Validator
+
+```js
+const ipns = require('ipns')
+
+const validator = ipns.validator
+```
+
+Contains an object with `validate (marshalledData, peerId, callback)` and `select (dataA, dataB, callback)` functions.
+
+The `validate` function aims to verify if an IPNS record is valid. First the record is unmarshalled, then the public key is obtained and finally the record is validated (signature and validity are verified).
+
+The `select` function is responsible for deciding which ipns record is the best (newer) between two records. Both records are unmarshalled and their sequece numbers are compared. If the first record provided is the newer, the operation result will be `0`, otherwise the operation result will be `1`.
+
 ## API
 
 #### Create record

--- a/src/index.js
+++ b/src/index.js
@@ -257,6 +257,38 @@ const extractPublicKeyFromId = (peerId) => {
   return crypto.keys.unmarshalPublicKey(decodedId.digest)
 }
 
+const marshal = ipnsEntryProto.encode
+
+const unmarshal = ipnsEntryProto.decode
+
+const validator = {
+  validate: (marshalledData, peerId, callback) => {
+    const receivedEntry = unmarshal(marshalledData)
+
+    // extract public key
+    extractPublicKey(peerId, receivedEntry, (err, pubKey) => {
+      if (err) {
+        return callback(err)
+      }
+
+      // Record validation
+      validate(pubKey, receivedEntry, (err) => {
+        if (err) {
+          return callback(err)
+        }
+
+        callback(null, true)
+      })
+    })
+  },
+  select: (dataA, dataB, callback) => {
+    const entryA = unmarshal(dataA)
+    const entryB = unmarshal(dataB)
+
+    callback(null, entryA.sequence > entryB.sequence ? 0 : 1)
+  }
+}
+
 module.exports = {
   // create ipns entry record
   create,
@@ -271,7 +303,9 @@ module.exports = {
   // get keys for routing
   getIdKeys,
   // marshal
-  marshal: ipnsEntryProto.encode,
+  marshal,
   // unmarshal
-  unmarshal: ipnsEntryProto.decode
+  unmarshal,
+  // validator
+  validator
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -278,7 +278,7 @@ describe('ipns', function () {
     })
   })
 
-  it('should use validator.select to select the newer record returning 0 if it is the first parameter', (done) => {
+  it('should use validator.select to select the first record because it is newer', (done) => {
     const sequence = 0
     const validity = 1000000
 
@@ -300,7 +300,7 @@ describe('ipns', function () {
     })
   })
 
-  it('should use validator.select to select the newer record returning 1 if it is the second parameter', (done) => {
+  it('should use validator.select to select the second record because it is newer', (done) => {
     const sequence = 0
     const validity = 1000000
 


### PR DESCRIPTION
`ipns` should offer a validator capable of validate records, as well select which one is the best record between two of them (using the sequence number).

This is particularly useful for validating libp2p records transparently, providing this validator.

Note: `go-ipns` also provides this feature [here](https://github.com/ipfs/go-ipns/blob/d5f9cadbca0a3de92ee17a5810a4ea50c6e514ce/record.go#L26)