### PR TITLE
feat: add routing id key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -210,6 +210,7 @@ const getIdKeys = (pid) => {
 
   return {
     pkKey: new Key(rawStdEncoding(Buffer.concat([pkBuffer, pid]))),
+    routingKey: new Key(`/ipns/${pid}`), // Added on https://github.com/ipfs/js-ipns/pull/6#issue-213631461 (ipnsKey will be deprecated in a future release)
     ipnsKey: new Key(rawStdEncoding(Buffer.concat([ipnsBuffer, pid])))
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -170,8 +170,10 @@ describe('ipns', function () {
     expect(idKeys).to.exist()
     expect(idKeys).to.have.a.property('pkKey')
     expect(idKeys).to.have.a.property('ipnsKey')
+    expect(idKeys).to.have.a.property('routingKey')
     expect(idKeys.pkKey).to.not.startsWith('/pk/')
     expect(idKeys.ipnsKey).to.not.startsWith('/ipns/')
+    expect(idKeys.routingKey).to.not.startsWith('/ipns/')
   })
 
   it('should be able to embed a public key in an ipns record', (done) => {


### PR DESCRIPTION
For the first step of `ipns working locally`, the records needed to be stored using `base32(/ipns/{cid})`, in order to guarantee interop with `go-ipfs`. 

However, integrating the DHT with `ipfs`, the `dht` will be responsible for the `base32` operation, as it does for all records stored in it, which in this case would end up on `base32(base32(/ipns/{cid}))`.

Accordingly, a new ID key was added (`routingKey`), which should be used for the routing part of `IPNS`. After this got released, the `ipnsKey` will not be needed anymore.

