### PR TITLE
fix: validator should create peer id

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const ipns = require('ipns')
 const validator = ipns.validator
 ```
 
-Contains an object with `validate (marshalledData, peerId, callback)` and `select (dataA, dataB, callback)` functions.
+Contains an object with `validate (marshalledData, key, callback)` and `select (dataA, dataB, callback)` functions.
 
 The `validate` function aims to verify if an IPNS record is valid. First the record is unmarshalled, then the public key is obtained and finally the record is validated (signature and validity are verified).
 

--- a/src/index.js
+++ b/src/index.js
@@ -283,8 +283,16 @@ const marshal = ipnsEntryProto.encode
 const unmarshal = ipnsEntryProto.decode
 
 const validator = {
-  validate: (marshalledData, peerId, callback) => {
+  validate: (marshalledData, key, callback) => {
     const receivedEntry = unmarshal(marshalledData)
+    const bufferId = key.slice('/ipns/'.length)
+    let peerId
+
+    try {
+      peerId = PeerId.createFromBytes(bufferId)
+    } catch (err) {
+      return callback(err)
+    }
 
     // extract public key
     extractPublicKey(peerId, receivedEntry, (err, pubKey) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -267,8 +267,9 @@ describe('ipns', function () {
         expect(err).to.not.exist()
 
         const marshalledData = ipns.marshal(entry)
+        const key = Buffer.from(`/ipns/${ipfsId.id}`)
 
-        ipns.validator.validate(marshalledData, ipfsId, (err, valid) => {
+        ipns.validator.validate(marshalledData, key, (err, valid) => {
           expect(err).to.not.exist()
           expect(valid).to.equal(true)
           done()
@@ -290,8 +291,9 @@ describe('ipns', function () {
         // corrupt the record by changing the value to random bytes
         entry.value = crypto.randomBytes(46).toString()
         const marshalledData = ipns.marshal(entry)
+        const key = Buffer.from(`/ipns/${ipfsId.id}`)
 
-        ipns.validator.validate(marshalledData, ipfsId, (err) => {
+        ipns.validator.validate(marshalledData, key, (err) => {
           expect(err).to.exist() // failed validation
           done()
         })


### PR DESCRIPTION
Since `libp2p-record` does not have author (removed for interop with `go-ipfs`), `validateRecord` must find the peerId, using the key (`/ipns/{peer_id}`)

BREAKING CHANGE: having the libp2p-record protobuf definition compliant with go-libp2p-record. Author and signature were removed.