### PR TITLE
fix: verify public key exists in validator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,12 @@ const extractPublicKey = (peerId, entry, callback) => {
     }
     return callback(null, pubKey)
   }
-  callback(null, peerId.pubKey)
+
+  if (peerId.pubKey) {
+    callback(null, peerId.pubKey)
+  } else {
+    callback(Object.assign(new Error('no public key is available'), { code: ERRORS.ERR_UNDEFINED_PARAMETER }))
+  }
 }
 
 // rawStdEncoding with RFC4648

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -256,6 +256,25 @@ describe('ipns', function () {
     })
   })
 
+  it('validator with no valid public key should error', (done) => {
+    const sequence = 0
+    const validity = 1000000
+
+    ipns.create(rsa, cid, sequence, validity, (err, entry) => {
+      expect(err).to.not.exist()
+
+      const marshalledData = ipns.marshal(entry)
+        const key = Buffer.from(`/ipns/${ipfsId.id}`)
+
+        ipns.validator.validate(marshalledData, key, (err, valid) => {
+          expect(err).to.exist()
+          expect(err.code).to.eql(ERRORS.ERR_UNDEFINED_PARAMETER)
+          expect(valid).to.not.exist()
+          done()
+        })
+    })
+  })
+
   it('should use validator.validate to validate a record', (done) => {
     const sequence = 0
     const validity = 1000000

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -264,14 +264,14 @@ describe('ipns', function () {
       expect(err).to.not.exist()
 
       const marshalledData = ipns.marshal(entry)
-        const key = Buffer.from(`/ipns/${ipfsId.id}`)
+      const key = Buffer.from(`/ipns/${ipfsId.id}`)
 
-        ipns.validator.validate(marshalledData, key, (err, valid) => {
-          expect(err).to.exist()
-          expect(err.code).to.eql(ERRORS.ERR_UNDEFINED_PARAMETER)
-          expect(valid).to.not.exist()
-          done()
-        })
+      ipns.validator.validate(marshalledData, key, (err, valid) => {
+        expect(err).to.exist()
+        expect(err.code).to.eql(ERRORS.ERR_UNDEFINED_PARAMETER)
+        expect(valid).to.not.exist()
+        done()
+      })
     })
   })
 


### PR DESCRIPTION
Running my local js-ipfs daemon it crashed when running the IPNS validator. Currently if the validator runs and cannot get an embedded public key it will attempt to use the public key of the peer. However, the validator doesn't have access to the peer public key, as it creates the peerId from bytes.

I'm not very familiar with the IPNS code base so there may be a better way to resolve this. This simply ensures that `extractPublicKey` actually returns a key.