### PR TITLE
chore: downgrade peer-id to the same version used by libp2p

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,23 +35,25 @@
   "dependencies": {
     "base32-encode": "^1.1.0",
     "debug": "^4.1.1",
-    "err-code": "^1.1.2",
+    "err-code": "^2.0.0",
     "interface-datastore": "~0.7.0",
     "left-pad": "^1.3.0",
-    "libp2p-crypto": "~0.17.0",
+    "libp2p-crypto": "^0.16.2",
     "multihashes": "~0.4.14",
-    "peer-id": "~0.13.2",
+    "peer-id": "^0.12.2",
+    "promisify-es6": "^1.0.3",
     "protons": "^1.0.1",
     "timestamp-nano": "^1.0.0"
   },
   "devDependencies": {
-    "aegir": "^18.0.3",
+    "aegir": "^20.3.1",
     "chai": "^4.2.0",
     "chai-bytes": "~0.1.2",
     "chai-string": "^1.5.0",
     "dirty-chai": "^2.0.1",
-    "ipfs": "~0.33.1",
-    "ipfsd-ctl": "~0.40.2"
+    "ipfs": "^0.37.1",
+    "ipfs-http-client": "^33.1.1",
+    "ipfsd-ctl": "^0.47.2"
   },
   "contributors": [
     "Diogo Silva <fsdiogo@gmail.com>",


### PR DESCRIPTION
Needed to upgrade `ipfs` to the latest `libp2p`, otherwise you end up with multiple versions of `peer-id` in the dependency tree and then libp2p thinks peer-ids are not peer-ids and can't dial anything.

Depends on libp2p/js-libp2p-crypto#158