### PR TITLE
fix: key encoding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -231,9 +231,9 @@ const getIdKeys = (pid) => {
   const ipnsBuffer = Buffer.from('/ipns/')
 
   return {
-    routingPubKey: new Key(Buffer.concat([pkBuffer, pid])), // Added on https://github.com/ipfs/js-ipns/pull/8#issue-213857876 (pkKey will be deprecated in a future release)
+    routingPubKey: new Key(Buffer.concat([pkBuffer, pid]), false), // Added on https://github.com/ipfs/js-ipns/pull/8#issue-213857876 (pkKey will be deprecated in a future release)
     pkKey: new Key(rawStdEncoding(Buffer.concat([pkBuffer, pid]))),
-    routingKey: new Key(Buffer.concat([ipnsBuffer, pid])), // Added on https://github.com/ipfs/js-ipns/pull/6#issue-213631461 (ipnsKey will be deprecated in a future release)
+    routingKey: new Key(Buffer.concat([ipnsBuffer, pid]), false), // Added on https://github.com/ipfs/js-ipns/pull/6#issue-213631461 (ipnsKey will be deprecated in a future release)
     ipnsKey: new Key(rawStdEncoding(Buffer.concat([ipnsBuffer, pid])))
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,6 +10,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 chai.use(chaiBytes)
 chai.use(chaiString)
+const { toB58String } = require('multihashes')
 
 const ipfs = require('ipfs')
 const ipfsHttpClient = require('ipfs-http-client')
@@ -155,6 +156,20 @@ describe('ipns', function () {
     expect(idKeys.pkKey).to.not.startsWith('/pk/')
     expect(idKeys.ipnsKey).to.not.startsWith('/ipns/')
     expect(idKeys.routingKey).to.not.startsWith('/ipns/')
+  })
+
+  it('should be able to turn routing key back into id', () => {
+    const keys = [
+      'QmQd5Enz5tzP8u5wHur8ADuJMbcNhEf86CkWkqRzoWUhst',
+      'QmW6mcoqDKJRch2oph2FmvZhPLJn6wPU648Vv9iMyMtmtG'
+    ]
+
+    keys.forEach(key => {
+      const { routingKey } = ipns.getIdKeys(fromB58String(key))
+      const id = toB58String(routingKey.toBuffer().slice(ipns.namespaceLength))
+
+      expect(id).to.equal(key)
+    })
   })
 
   it('should be able to embed a public key in an ipns record', async () => {


### PR DESCRIPTION
The boolean argument to `new Key` specifies whether to try to clean the key up - remove trailing slashes, etc.

Here we're putting potentially non-printable characters into the key so we don't want to do any such operation.

fixes ipfs/js-ipfs#2930