### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  webpack: {
+    node: {
+      path: true,
+
+      Buffer: true
+    }
+  }
+}

--- a/.aegir.js
+++ b/.aegir.js
@@ -3,8 +3,10 @@
 module.exports = {
   webpack: {
     node: {
+      // needed by the ipfs-repo-migrations module
       path: true,
 
+      // needed by the abstract-leveldown module
       Buffer: true
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IPNS
+# IPNS <!-- omit in toc -->
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
@@ -12,20 +12,30 @@
 
 This module contains all the necessary code for creating, understanding and validating IPNS records.
 
-## Lead Maintainer
+## Lead Maintainer <!-- omit in toc -->
 
 [Vasco Santos](https://github.com/vasco-santos).
 
-## Table of Contents
+## Table of Contents <!-- omit in toc -->
 
-- [Install](#install)
 - [Usage](#usage)
-  - [Create Record](#create-record)
-  - [Validate Record](#validate-record)
-  - [Embed public key to record](#embed-public-key-to-record)
-  - [Extract public key from record](#extract-public-key-from-record)
-  - [Datastore key](#datastore-key)
+    - [Create record](#create-record)
+    - [Validate record](#validate-record)
+    - [Embed public key to record](#embed-public-key-to-record)
+    - [Extract public key from record](#extract-public-key-from-record)
+    - [Datastore key](#datastore-key)
+    - [Marshal data with proto buffer](#marshal-data-with-proto-buffer)
+    - [Unmarshal data from proto buffer](#unmarshal-data-from-proto-buffer)
+    - [Validator](#validator)
 - [API](#api)
+    - [Create record](#create-record-1)
+    - [Validate record](#validate-record-1)
+    - [Datastore key](#datastore-key-1)
+    - [Marshal data with proto buffer](#marshal-data-with-proto-buffer-1)
+    - [Unmarshal data from proto buffer](#unmarshal-data-from-proto-buffer-1)
+    - [Embed public key to record](#embed-public-key-to-record-1)
+    - [Extract public key from record](#extract-public-key-from-record-1)
+    - [Namespace](#namespace)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -136,13 +146,13 @@ Create an IPNS record for being stored in a protocol buffer.
 - `lifetime` (string): lifetime of the record (in milliseconds).
 
 Returns a `Promise` that resolves to an object with the entry's properties eg:
-  
+
 ```js
 {
-  value: '/ipfs/QmWEekX7EZLUd9VXRNMRXW3LXe4F6x7mB8oPxY5XLptrBq',
-  signature: Buffer,
+  value: Uint8Array,
+  signature: Uint8Array,
   validityType: 0,
-  validity: '2018-06-27T14:49:14.074000000Z',
+  validity: Uint8Array,
   sequence: 2
 }
 ```
@@ -189,7 +199,7 @@ const data = ipns.unmarshal(storedData)
 
 Returns the entry data structure after being serialized.
 
-- `storedData` (Buffer): ipns entry record serialized.
+- `storedData` (Uint8Array): ipns entry record serialized.
 
 #### Embed public key to record
 

--- a/package.json
+++ b/package.json
@@ -33,26 +33,26 @@
   },
   "homepage": "https://github.com/ipfs/js-ipns#readme",
   "dependencies": {
-    "buffer": "^5.6.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
-    "interface-datastore": "^1.0.2",
+    "interface-datastore": "^2.0.0",
     "libp2p-crypto": "^0.17.1",
     "multibase": "^3.0.0",
     "multihashes": "^3.0.1",
-    "peer-id": "^0.13.6",
-    "protons": "^1.0.1",
-    "timestamp-nano": "^1.0.0"
+    "peer-id": "^0.14.0",
+    "protons": "^2.0.0",
+    "timestamp-nano": "^1.0.0",
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^23.0.0",
+    "aegir": "^25.1.0",
     "chai": "^4.2.0",
     "chai-bytes": "~0.1.2",
     "chai-string": "^1.5.0",
     "dirty-chai": "^2.0.1",
     "ipfs": "^0.49.0",
     "ipfs-http-client": "^46.0.0",
-    "ipfsd-ctl": "^4.0.1"
+    "ipfsd-ctl": "^6.0.0"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
     "interface-datastore": "^2.0.0",
-    "libp2p-crypto": "^0.17.1",
+    "libp2p-crypto": "^0.18.0",
     "multibase": "^3.0.0",
     "multihashes": "^3.0.1",
     "peer-id": "^0.14.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ const crypto = require('libp2p-crypto')
 const PeerId = require('peer-id')
 const multihash = require('multihashes')
 const errCode = require('err-code')
-const { Buffer } = require('buffer')
 const multibase = require('multibase')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 const uint8ArrayToString = require('uint8arrays/to-string')
@@ -196,7 +195,7 @@ const extractPublicKey = (peerId, entry) => {
   if (entry.pubKey) {
     let pubKey
     try {
-      pubKey = crypto.keys.unmarshalPublicKey(Buffer.from(entry.pubKey))
+      pubKey = crypto.keys.unmarshalPublicKey(entry.pubKey)
     } catch (err) {
       log.error(err)
       throw err


### PR DESCRIPTION
BREAKING CHANGES:

- All deps of this module use Uint8Arrays instead of Buffers
- value and validity fields of IPNSEntries are now Uint8Arrays instead
  of Strings as they are `bytes` in the protobuf definition