### PR TITLE
chore: update deps

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -3,6 +3,9 @@
 module.exports = {
   webpack: {
     node: {
+      // required by the cbor module
+      stream: true,
+
       // needed by the ipfs-repo-migrations module
       path: true,
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
+  - 'lts/*'
+  - 'node'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "chai-bytes": "~0.1.2",
     "chai-string": "^1.5.0",
     "dirty-chai": "^2.0.1",
-    "ipfs": "^0.49.0",
+    "ipfs": "^0.50.2",
     "ipfs-http-client": "^47.0.1",
-    "ipfsd-ctl": "^6.0.0"
+    "ipfsd-ctl": "^7.0.0"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>",


### PR DESCRIPTION
Updates dev dependencies `ipfsd-ctl` + `ipfs` and changes CI's node versions as hapi dropped support for node < 12

Closes #69 and #71 