### PR TITLE
fix: add files list to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "test:browser": "aegir test -t browser -t webworker",
     "test:node": "aegir test -t node"
   },
+  "files": [
+    "src",
+    "dist"
+  ],
   "pre-push": [
     "lint",
     "test"


### PR DESCRIPTION
Otherwise the dist folder doesn't get published since it's in the `.gitignore` file.

`npm pack` before:

```
npm notice 📦  ipns@0.9.0
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 508B   src/errors.js
npm notice 11.9kB src/index.js
npm notice 9.6kB  test/index.spec.js
npm notice 12.9kB src/pb/ipns.js
npm notice 1.5kB  src/utils.js
npm notice 2.4kB  package.json
npm notice 203B   tsconfig.json
npm notice 7.6kB  CHANGELOG.md
npm notice 650B   .github/ISSUE_TEMPLATE/open_an_issue.md
npm notice 7.6kB  README.md
npm notice 639B   src/pb/ipns.proto
npm notice 2.8kB  src/pb/ipns.d.ts
npm notice 412B   src/types.d.ts
npm notice 946B   .travis.yml
npm notice 2.9kB  .github/config.yml
npm notice 311B   .github/ISSUE_TEMPLATE/config.yml
npm notice === Tarball Details ===
npm notice name:          ipns
npm notice version:       0.9.0
npm notice filename:      ipns-0.9.0.tgz
npm notice package size:  17.8 kB
npm notice unpacked size: 63.9 kB
npm notice shasum:        c0726a431a7e7a1a94f5632018ae77a58aeb1199
npm notice integrity:     sha512-sd25DLGI6i2qN[...]AQ5wKq/OMPBYw==
npm notice total files:   17
npm notice
ipns-0.9.0.tgz
```

`npm pack` after:

```
npm notice 📦  ipns@0.9.0
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 508B   src/errors.js
npm notice 11.9kB src/index.js
npm notice 12.9kB src/pb/ipns.js
npm notice 1.5kB  src/utils.js
npm notice 2.4kB  package.json
npm notice 109B   dist/src/errors.d.ts.map
npm notice 626B   dist/src/index.d.ts.map
npm notice 154B   dist/src/utils.d.ts.map
npm notice 7.6kB  CHANGELOG.md
npm notice 7.6kB  README.md
npm notice 639B   src/pb/ipns.proto
npm notice 395B   dist/src/errors.d.ts
npm notice 4.5kB  dist/src/index.d.ts
npm notice 2.8kB  dist/src/pb/ipns.d.ts
npm notice 2.8kB  src/pb/ipns.d.ts
npm notice 412B   dist/src/types.d.ts
npm notice 412B   src/types.d.ts
npm notice 132B   dist/src/utils.d.ts
npm notice === Tarball Details ===
npm notice name:          ipns
npm notice version:       0.9.0
npm notice filename:      ipns-0.9.0.tgz
npm notice package size:  15.2 kB
npm notice unpacked size: 58.5 kB
npm notice shasum:        9c808a492a0459af75d50dfdc2c7b6b23cb7e78c
npm notice integrity:     sha512-aWbgqDY70l10V[...]tQe9WrH6/vBBg==
npm notice total files:   19
npm notice
ipns-0.9.0.tgz
```