### PR TITLE
fix: remove value ambiguity

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -22,7 +22,7 @@ const ERRORS = require('../src/errors')
 describe('ipns', function () {
   this.timeout(20 * 1000)
 
-  const cid = 'QmWEekX7EZLUd9VXRNMRXW3LXe4F6x7mB8oPxY5XLptrBq'
+  const cid = uint8ArrayFromString('QmWEekX7EZLUd9VXRNMRXW3LXe4F6x7mB8oPxY5XLptrBq')
 
   /** @type {{ id: string, publicKey: string }} */
   let ipfsId
@@ -44,7 +44,7 @@ describe('ipns', function () {
 
     const entry = await ipns.create(rsa, cid, sequence, validity)
     expect(entry).to.deep.include({
-      value: uint8ArrayFromString(cid),
+      value: cid,
       sequence: sequence
     })
     expect(entry).to.have.property('validity')


### PR DESCRIPTION
We accept strings as values to publish, but the actual datatype is Uint8Array.  Likewise these Uint8Arrays get turned into strings when passed back, but in JavaScript this can be a lossy translation as bytes values above 127 are interpreted as multi-byte UTF8 code points.
    
This PR removes strings as acceptable input types and only accepts Uint8Arrays.

It also demands record TTLs be numbers and not strings.
    
BREAKING CHANGE: strings are no longer accepted as valid values to publish or for ttls, use Uint8Arrays and numbers instead