### PR TITLE
fix: encode ipns key correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,7 @@ const extractPublicKey = (peerId, entry) => {
  *
  * @param {Uint8Array} key
  */
-const rawStdEncoding = (key) => multibase.encode('base32', key).toString().slice(1).toUpperCase()
+const rawStdEncoding = (key) => uint8ArrayToString(multibase.encode('base32', key)).slice(1).toUpperCase()
 
 /**
  * Get key for storing the record locally.

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -130,6 +130,7 @@ describe('ipns', function () {
     const datastoreKey = ipns.getLocalKey(fromB58String(ipfsId.id))
 
     expect(datastoreKey).to.exist()
+    expect(datastoreKey.toString()).to.startWith('/ipns/CIQ')
   })
 
   it('should get id keys correctly', () => {


### PR DESCRIPTION
Use `uint8ArrayToString` instead of calling `.toString()` on the Uint8Array instance directly.