### PR TITLE
chore: remove chai deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,8 @@
     "uint8arrays": "^2.0.5"
   },
   "devDependencies": {
-    "@types/chai-string": "^1.4.2",
     "@types/debug": "^4.1.5",
-    "aegir": "^32.2.0",
-    "chai": "^4.2.0",
-    "chai-bytes": "~0.1.2",
-    "chai-string": "^1.5.0",
-    "dirty-chai": "^2.0.1",
+    "aegir": "^33.1.0",
     "npm-run-all": "^4.1.5",
     "util": "^0.12.3"
   },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,14 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const chaiBytes = require('chai-bytes')
-const chaiString = require('chai-string')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(chaiBytes)
-chai.use(chaiString)
+const { expect } = require('aegir/utils/chai')
 const { toB58String } = require('multihashes')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 const PeerId = require('peer-id')


### PR DESCRIPTION
As of `aegir@33.1.0`, `chai-string` and `chai-bytes` are bundled with
aegir so no need to depend on them separately.