### PR TITLE
fix: ipns validate should return void

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -351,7 +351,6 @@ const validator = {
 
     // Record validation
     await validate(pubKey, receivedEntry)
-    return true
   },
   /**
    * @param {Uint8Array} dataA

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -219,8 +219,7 @@ describe('ipns', function () {
     const marshalledData = ipns.marshal(entry)
     const key = uint8ArrayFromString(`/ipns/${ipfsId.id}`)
 
-    const valid = await ipns.validator.validate(marshalledData, key)
-    expect(valid).to.equal(true)
+    await ipns.validator.validate(marshalledData, key)
   })
 
   it('should use validator.validate to verify that a record is not valid', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,10 @@
     "outDir": "dist"
   },
   "include": [
-    "test",
     "src"
   ],
   "exclude": [
-    "src/pb/ipns.js"
+    "src/pb/ipns.js",
+    "test"
   ]
 }


### PR DESCRIPTION
BREAKING CHANGE: ipns validate function returns a void promise instead of boolean promise