### PR TITLE
chore: update interface datastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cborg": "^1.3.3",
     "debug": "^4.2.0",
     "err-code": "^3.0.1",
-    "interface-datastore": "^4.0.0",
+    "interface-datastore": "^4.0.2",
     "libp2p-crypto": "^0.19.0",
     "long": "^4.0.0",
     "multibase": "^4.0.2",


### PR DESCRIPTION
Demand a version that depends on ipfs-utils@8.x