### PR TITLE
fix: parse peer id from message correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const ERRORS = require('./errors')
 const ID_MULTIHASH_CODE = identity.code
 
 const namespace = '/ipns/'
+const IPNS_PREFIX = uint8ArrayFromString('/ipns/')
 
 /**
  * @typedef {import('./types').IPNSEntry} IPNSEntry
@@ -453,8 +454,8 @@ const validator = {
    */
   validate: async (marshalledData, key) => {
     const receivedEntry = unmarshal(marshalledData)
-    const bufferId = uint8ArrayToString(key).substring('/ipns/'.length)
-    const peerId = PeerId.parse(bufferId)
+    const bufferId = key.slice(IPNS_PREFIX.length)
+    const peerId = PeerId.createFromBytes(bufferId)
 
     // extract public key
     const pubKey = extractPublicKey(peerId, receivedEntry)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,6 +4,7 @@
 const { expect } = require('aegir/utils/chai')
 const { base58btc } = require('multiformats/bases/base58')
 const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayConcat = require('uint8arrays/concat')
 const PeerId = require('peer-id')
 
 const crypto = require('libp2p-crypto')
@@ -193,7 +194,8 @@ describe('ipns', function () {
     const entry = await ipns.create(rsa, cid, sequence, validity)
 
     const marshalledData = ipns.marshal(entry)
-    const key = uint8ArrayFromString(`/ipns/${ipfsId.id}`)
+    const keyBytes = base58btc.decode(`z${ipfsId.id}`)
+    const key = uint8ArrayConcat([uint8ArrayFromString('/ipns/'), keyBytes])
 
     try {
       await ipns.validator.validate(marshalledData, key)
@@ -222,7 +224,9 @@ describe('ipns', function () {
     await ipns.embedPublicKey(rsa.public, entry)
 
     const marshalledData = ipns.marshal(entry)
-    const key = uint8ArrayFromString(`/ipns/${ipfsId.id}`)
+
+    const keyBytes = base58btc.decode(`z${ipfsId.id}`)
+    const key = uint8ArrayConcat([uint8ArrayFromString('/ipns/'), keyBytes])
 
     await ipns.validator.validate(marshalledData, key)
   })
@@ -237,7 +241,9 @@ describe('ipns', function () {
     // corrupt the record by changing the value to random bytes
     entry.value = crypto.randomBytes(46)
     const marshalledData = ipns.marshal(entry)
-    const key = uint8ArrayFromString(`/ipns/${ipfsId.id}`)
+
+    const keyBytes = base58btc.decode(`z${ipfsId.id}`)
+    const key = uint8ArrayConcat([uint8ArrayFromString('/ipns/'), keyBytes])
 
     try {
       await ipns.validator.validate(marshalledData, key)


### PR DESCRIPTION
Peer IDs are sent as a buffer containing the utf bytes for `/ipns/`
then the bytes that make up the peer id.

Our tests were using a buffer that contained the utf bytes for `/ipns/`
followed by the utf bytes for the base encoded peer id, which is wrong.

I think this only worked previously because the validator passed the
bytes to `PeerId.createFromBytes` which passes them to the `cids` `CID`
class constructor which is a lot more forgiving in terms of input than
the multiformats `CID` class.