### PR TITLE
Fix Dht select when records.length == 1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -479,6 +479,7 @@ export const validator = {
    * @param {Uint8Array} dataB
    */
   select: (dataA, dataB) => {
+    if(!dataB) return 0 //when only one record
     const entryA = unmarshal(dataA)
     const entryB = unmarshal(dataB)
 


### PR DESCRIPTION
https://github.com/ipfs/js-ipfs/issues/3850

Main problem is:
There is only one record, `dataB` is undefined, then throw exception in `unmarshal`.
So can't select the current `dataA`,


Other solution: fix dht, when only one records, not to call select
* https://github.com/libp2p/js-libp2p-record/blob/26085908adc7dedc841e5a5f3825e432cb19b8a2/src/selection.js#L13