### PR TITLE
chore: update deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
-        node-version: 16
+        node-version: lts/*
     - run: npm install
     - run: npm run build
     - run: npm run lint
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [14, 16]
+        node: [16]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
@@ -50,9 +50,9 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: lts/*
       - run: npm install
       - run: npm run test -- -t ${{ matrix.type }} -- --browser ${{ matrix.browser }}
   test-electron:
@@ -67,9 +67,9 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: lts/*
       - run: npm install
       - uses: GabrielBB/xvfb-action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "debug": "^4.2.0",
     "err-code": "^3.0.1",
     "interface-datastore": "^6.0.2",
-    "libp2p-crypto": "^0.20.0",
+    "libp2p-crypto": "^0.21.0",
     "long": "^4.0.0",
     "multiformats": "^9.4.5",
-    "peer-id": "^0.15.0",
+    "peer-id": "^0.16.0",
     "protobufjs": "^6.10.2",
     "timestamp-nano": "^1.0.0",
     "uint8arrays": "^3.0.0"


### PR DESCRIPTION
Pulls in new libp2p-crypto and peer-id

BREAKING CHANGE: requires node 15+