### PR TITLE
Add ability to create unsigned IPNS records for use with crypto wallets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ export interface IPNSEntry {
   data?: Uint8Array // extensible data
 }
 
-//
 export type UnsignedIPNSEntry = Omit<IPNSEntry, 'signature' | 'signatureV2'> & {
   dataForSignatureV1: Uint8Array
   dataForSignatureV2: Uint8Array

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -206,6 +206,28 @@ describe('ipns', function () {
     await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected().with.property('code', ERRORS.ERR_UNDEFINED_PARAMETER)
   })
 
+  it('should be able to create an unsigned record', async () => {
+    const sequence = 0
+    const validity = 1000000
+    const cid = uint8ArrayFromString('/ipfs/bafybeicq6y27fphdisjtxaybzxold7dczhvxiiyn3bvkyht7b36lveerrm')
+
+    const record = ipns.createUnsigned(cid, sequence, validity)
+
+    expect(record).to.not.have.property('signatureV2')
+    expect(record).to.not.have.property('signature')
+
+    expect(record).to.have.property('dataForSignatureV1')
+    expect(record).to.have.property('dataForSignatureV2')
+    expect(record).to.deep.include({
+      value: cid,
+      sequence: BigInt(sequence)
+    })
+    expect(record).to.have.property('validity')
+    expect(record).to.have.property('validityType')
+    expect(record).to.have.property('data')
+    // await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected().with.property('code', ERRORS.ERR_UNDEFINED_PARAMETER)
+  })
+
   it('should be able to export a previously embedded public key from an ipns record', async () => {
     const sequence = 0
     const validity = 1000000


### PR DESCRIPTION
This PR lays the groundwork for creating IPNS records that can be signed by a crypto wallet like metamask.