### PR TITLE
deps!: update multiformats to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,21 +169,21 @@
   },
   "dependencies": {
     "@libp2p/crypto": "^1.0.0",
-    "@libp2p/interface-dht": "^1.0.1",
+    "@libp2p/interface-dht": "^2.0.0",
     "@libp2p/interface-keys": "^1.0.3",
-    "@libp2p/interface-peer-id": "^1.0.4",
+    "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/logger": "^2.0.0",
-    "@libp2p/peer-id": "^1.1.9",
+    "@libp2p/peer-id": "^2.0.0",
     "cborg": "^1.3.3",
     "err-code": "^3.0.1",
     "interface-datastore": "^7.0.0",
-    "multiformats": "^10.0.0",
+    "multiformats": "^11.0.0",
     "protons-runtime": "^4.0.1",
     "timestamp-nano": "^1.0.0",
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
-    "@libp2p/peer-id-factory": "^1.0.9",
+    "@libp2p/peer-id-factory": "^2.0.0",
     "aegir": "^37.0.11",
     "protons": "^6.0.1"
   }


### PR DESCRIPTION
The CID class in multiformats v11.x.x shipped with a breaking change so update all deps to use the latest version.