### PR TITLE
fix!: only accept CIDs, PeerIds or strings as values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ const defaultCreateOptions: CreateOptions = {
  * The passed value can be a CID, a PeerID or an arbitrary string path.
  *
  * * CIDs will be converted to v1 and stored in the record as a string similar to: `/ipfs/${cid}`
- * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${peerId}`
+ * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${cidV1Libp2pKey}`
  * * String paths will be stored in the record as-is, but they must start with `"/"`
  *
  * @param {PeerId} peerId - peer id containing private key for signing the record.
@@ -111,7 +111,7 @@ export async function create (peerId: PeerId, value: CID | PeerId | string, seq:
  * The passed value can be a CID, a PeerID or an arbitrary string path.
  *
  * * CIDs will be converted to v1 and stored in the record as a string similar to: `/ipfs/${cid}`
- * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${peerId}`
+ * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${cidV1Libp2pKey}`
  * * String paths will be stored in the record as-is, but they must start with `"/"`
  *
  * @param {PeerId} peerId - PeerId containing private key for signing the record.

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { IpnsEntry } from './pb/ipns.js'
 import { createCborData, ipnsRecordDataForV1Sig, ipnsRecordDataForV2Sig, normalizeValue } from './utils.js'
 import type { PrivateKey } from '@libp2p/interface-keys'
 import type { PeerId } from '@libp2p/interface-peer-id'
+import type { CID } from 'multiformats/cid'
 
 const log = logger('ipns')
 const ID_MULTIHASH_CODE = identity.code
@@ -79,15 +80,21 @@ const defaultCreateOptions: CreateOptions = {
  * The IPNS Record validity should follow the [RFC3339]{@link https://www.ietf.org/rfc/rfc3339.txt} with nanoseconds precision.
  * Note: This function does not embed the public key. If you want to do that, use `EmbedPublicKey`.
  *
+ * The passed value can be a CID, a PeerID or an arbitrary string path.
+ *
+ * * CIDs will be converted to v1 and stored in the record as a string similar to: `/ipfs/${cid}`
+ * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${peerId}`
+ * * String paths will be stored in the record as-is, but they must start with `"/"`
+ *
  * @param {PeerId} peerId - peer id containing private key for signing the record.
- * @param {string | Uint8Array} value - content path to be stored in the record.
+ * @param {CID | PeerId | string} value - content to be stored in the record.
  * @param {number | bigint} seq - number representing the current version of the record.
  * @param {number} lifetime - lifetime of the record (in milliseconds).
  * @param {CreateOptions} options - additional create options.
  */
-export async function create (peerId: PeerId, value: string | Uint8Array, seq: number | bigint, lifetime: number, options?: CreateV2OrV1Options): Promise<IPNSRecord>
-export async function create (peerId: PeerId, value: string | Uint8Array, seq: number | bigint, lifetime: number, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function create (peerId: PeerId, value: string | Uint8Array, seq: number | bigint, lifetime: number, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord | IPNSRecordV2> {
+export async function create (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, lifetime: number, options?: CreateV2OrV1Options): Promise<IPNSRecord>
+export async function create (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, lifetime: number, options: CreateV2Options): Promise<IPNSRecordV2>
+export async function create (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, lifetime: number, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord | IPNSRecordV2> {
   // Validity in ISOString with nanoseconds precision and validity type EOL
   const expirationDate = new NanoDate(Date.now() + Number(lifetime))
   const validityType = IpnsEntry.ValidityType.EOL
@@ -101,15 +108,21 @@ export async function create (peerId: PeerId, value: string | Uint8Array, seq: n
  * Same as create(), but instead of generating a new Date, it receives the intended expiration time
  * WARNING: nano precision is not standard, make sure the value in seconds is 9 orders of magnitude lesser than the one provided.
  *
+ * The passed value can be a CID, a PeerID or an arbitrary string path.
+ *
+ * * CIDs will be converted to v1 and stored in the record as a string similar to: `/ipfs/${cid}`
+ * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${peerId}`
+ * * String paths will be stored in the record as-is, but they must start with `"/"`
+ *
  * @param {PeerId} peerId - PeerId containing private key for signing the record.
- * @param {string | Uint8Array} value - content path to be stored in the record.
+ * @param {CID | PeerId | string} value - content to be stored in the record.
  * @param {number | bigint} seq - number representing the current version of the record.
  * @param {string} expiration - expiration datetime for record in the [RFC3339]{@link https://www.ietf.org/rfc/rfc3339.txt} with nanoseconds precision.
  * @param {CreateOptions} options - additional creation options.
  */
-export async function createWithExpiration (peerId: PeerId, value: string | Uint8Array, seq: number | bigint, expiration: string, options?: CreateV2OrV1Options): Promise<IPNSRecord>
-export async function createWithExpiration (peerId: PeerId, value: string | Uint8Array, seq: number | bigint, expiration: string, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function createWithExpiration (peerId: PeerId, value: string | Uint8Array, seq: number | bigint, expiration: string, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord | IPNSRecordV2> {
+export async function createWithExpiration (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, expiration: string, options?: CreateV2OrV1Options): Promise<IPNSRecord>
+export async function createWithExpiration (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, expiration: string, options: CreateV2Options): Promise<IPNSRecordV2>
+export async function createWithExpiration (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, expiration: string, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord | IPNSRecordV2> {
   const expirationDate = NanoDate.fromString(expiration)
   const validityType = IpnsEntry.ValidityType.EOL
 
@@ -119,7 +132,7 @@ export async function createWithExpiration (peerId: PeerId, value: string | Uint
   return _create(peerId, value, seq, validityType, expirationDate, ttlNs, options)
 }
 
-const _create = async (peerId: PeerId, value: string | Uint8Array, seq: number | bigint, validityType: IpnsEntry.ValidityType, expirationDate: NanoDate, ttl: bigint, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord | IPNSRecordV2> => {
+const _create = async (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, validityType: IpnsEntry.ValidityType, expirationDate: NanoDate, ttl: bigint, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord | IPNSRecordV2> => {
   seq = BigInt(seq)
   const isoValidity = uint8ArrayFromString(expirationDate.toString())
   const normalizedValue = normalizeValue(value)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import { logger } from '@libp2p/logger'
 import { peerIdFromBytes, peerIdFromKeys } from '@libp2p/peer-id'
 import * as cborg from 'cborg'
 import errCode from 'err-code'
+import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import NanoDate from 'timestamp-nano'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
@@ -17,6 +18,7 @@ import type { PublicKey } from '@libp2p/interface-keys'
 
 const log = logger('ipns:utils')
 const IPNS_PREFIX = uint8ArrayFromString('/ipns/')
+const LIBP2P_CID_CODEC = 114
 
 /**
  * Convert a JavaScript date into an `RFC3339Nano` formatted
@@ -288,6 +290,11 @@ export const normalizeValue = (value?: CID | PeerId | string | Uint8Array): stri
     // if we have a CID, turn it into an ipfs path
     const cid = CID.asCID(value)
     if (cid != null) {
+      // PeerID encoded as a CID
+      if (cid.code === LIBP2P_CID_CODEC) {
+        return `/ipns/${base58btc.encode(cid.multihash.bytes).substring(1)}`
+      }
+
       return `/ipfs/${cid.toV1().toString()}`
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,8 +262,8 @@ export const parseCborData = (buf: Uint8Array): IPNSRecordData => {
 
 /**
  * Normalizes the given record value. It ensures it is a PeerID, a CID or a
- * string starting with '/'. PeerIDs become `/ipns/${peerId}`, CIDs become
- * `/ipfs/${cidAsV1}`.
+ * string starting with '/'. PeerIDs become `/ipns/${cidV1Libp2pKey}`,
+ * CIDs become `/ipfs/${cidAsV1}`.
  */
 export const normalizeValue = (value?: CID | PeerId | string | Uint8Array): string => {
   if (value != null) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { logger } from '@libp2p/logger'
 import { peerIdFromBytes, peerIdFromKeys } from '@libp2p/peer-id'
 import * as cborg from 'cborg'
 import errCode from 'err-code'
-import { base58btc } from 'multiformats/bases/base58'
+import { base36 } from 'multiformats/bases/base36'
 import { CID } from 'multiformats/cid'
 import NanoDate from 'timestamp-nano'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
@@ -269,7 +269,7 @@ export const normalizeValue = (value?: CID | PeerId | string | Uint8Array): stri
   if (value != null) {
     // if we have a PeerId, turn it into an ipns path
     if (isPeerId(value)) {
-      return `/ipns/${value.toString()}`
+      return `/ipns/${value.toCID().toString(base36)}`
     }
 
     // if the value is bytes, stringify it and see if we have a path
@@ -292,7 +292,7 @@ export const normalizeValue = (value?: CID | PeerId | string | Uint8Array): stri
     if (cid != null) {
       // PeerID encoded as a CID
       if (cid.code === LIBP2P_CID_CODEC) {
-        return `/ipns/${base58btc.encode(cid.multihash.bytes).substring(1)}`
+        return `/ipns/${cid.toString(base36)}`
       }
 
       return `/ipfs/${cid.toV1().toString()}`

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,6 +6,7 @@ import { peerIdFromKeys, peerIdFromString } from '@libp2p/peer-id'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
 import * as cbor from 'cborg'
+import { base36 } from 'multiformats/bases/base36'
 import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import { toString as uint8ArrayToString } from 'uint8arrays'
@@ -153,14 +154,14 @@ describe('ipns', function () {
 
   it('should normalize value when creating a recursive ipns record (peer id)', async () => {
     const inputValue = await createEd25519PeerId()
-    const expectedValue = `/ipns/${inputValue.toString()}`
+    const expectedValue = `/ipns/${inputValue.toCID().toString(base36)}`
     const record = await ipns.create(peerId, inputValue, 0, 1000000)
     expect(record.value).to.equal(expectedValue)
   })
 
   it('should normalize value when creating a recursive ipns record (peer id as CID)', async () => {
     const inputValue = await createEd25519PeerId()
-    const expectedValue = `/ipns/${inputValue.toString()}`
+    const expectedValue = `/ipns/${inputValue.toCID().toString(base36)}`
     const record = await ipns.create(peerId, inputValue.toCID(), 0, 1000000)
     expect(record.value).to.equal(expectedValue)
   })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -158,6 +158,13 @@ describe('ipns', function () {
     expect(record.value).to.equal(expectedValue)
   })
 
+  it('should normalize value when creating a recursive ipns record (peer id as CID)', async () => {
+    const inputValue = await createEd25519PeerId()
+    const expectedValue = `/ipns/${inputValue.toString()}`
+    const record = await ipns.create(peerId, inputValue.toCID(), 0, 1000000)
+    expect(record.value).to.equal(expectedValue)
+  })
+
   it('should normalize value when creating an ipns record (v0 cid)', async () => {
     const inputValue = CID.parse('QmWEekX7EZLUd9VXRNMRXW3LXe4F6x7mB8oPxY5XLptrBq')
     const expectedValue = '/ipfs/bafybeidvkqhl6dwsdzx5km7tupo33ywt7czkl5topwogxx6lybko2d7pua'


### PR DESCRIPTION
This module has accepted `Uint8Array`s as values to store in IPNS
records which means it has been mis-used to create records with
raw CID bytes.

To ensure this doesn't happen in future, accept only CIDs, PeerIds
or arbitrary path strings prefixed with `"/"`.