### PR TITLE
fix: mark package as side-effect free

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -2,6 +2,6 @@
 /** @type {import('aegir').PartialOptions} */
 export default {
   build: {
-    bundlesizeMax: '143KB'
+    bundlesizeMax: '60KB'
   }
 }

--- a/package.json
+++ b/package.json
@@ -183,5 +183,6 @@
     "@libp2p/peer-id-factory": "^4.0.2",
     "aegir": "^42.1.1",
     "protons": "^7.3.3"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
[Tree shaking](https://webpack.js.org/guides/tree-shaking/) results in smaller web bundles by deleting unused code.

This module is side-effect free so mark it as such to signal to bundlers that unused exports can be excluded from bundles.