### PR TITLE
fix!: update to libp2p@2.x.x deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
   - [Validate record](#validate-record)
   - [Embed public key to record](#embed-public-key-to-record)
   - [Extract public key from record](#extract-public-key-from-record)
-  - [Datastore key](#datastore-key)
   - [Marshal data with proto buffer](#marshal-data-with-proto-buffer)
   - [Unmarshal data from proto buffer](#unmarshal-data-from-proto-buffer)
   - [Validator](#validator)
@@ -80,20 +79,6 @@ const ipnsRecordWithEmbeddedPublicKey = await ipns.embedPublicKey(publicKey, ipn
 import * as ipns from 'ipns'
 
 const publicKey = await ipns.extractPublicKey(peerId, ipnsRecord)
-```
-
-### Datastore key
-
-```js
-import * as ipns from 'ipns'
-
-ipns.getLocalKey(peerId)
-```
-
-Returns a key to be used for storing the IPNS record locally, that is:
-
-```
-/ipns/${base32(<HASH>)}
 ```
 
 ### Marshal data with proto buffer

--- a/package.json
+++ b/package.json
@@ -166,23 +166,21 @@
     "docs:no-publish": "NODE_OPTIONS=--max_old_space_size=8192 aegir docs --publish false"
   },
   "dependencies": {
-    "@libp2p/crypto": "^4.0.0",
-    "@libp2p/interface": "^1.1.0",
-    "@libp2p/logger": "^4.0.3",
-    "@libp2p/peer-id": "^4.0.3",
-    "cborg": "^4.0.1",
-    "err-code": "^3.0.1",
-    "interface-datastore": "^8.1.0",
-    "multiformats": "^13.0.0",
-    "protons-runtime": "^5.2.1",
-    "timestamp-nano": "^1.0.0",
+    "@libp2p/crypto": "^5.0.0",
+    "@libp2p/interface": "^2.0.0",
+    "@libp2p/logger": "^5.0.0",
+    "cborg": "^4.2.3",
+    "interface-datastore": "^8.3.0",
+    "multiformats": "^13.2.2",
+    "protons-runtime": "^5.5.0",
+    "timestamp-nano": "^1.0.1",
     "uint8arraylist": "^2.4.8",
-    "uint8arrays": "^5.0.1"
+    "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
-    "@libp2p/peer-id-factory": "^4.0.2",
+    "@libp2p/peer-id": "^5.0.0",
     "aegir": "^44.1.1",
-    "protons": "^7.3.3"
+    "protons": "^7.6.0"
   },
   "sideEffects": false
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,13 +1,71 @@
-export const ERR_IPNS_EXPIRED_RECORD = 'ERR_IPNS_EXPIRED_RECORD'
-export const ERR_UNRECOGNIZED_VALIDITY = 'ERR_UNRECOGNIZED_VALIDITY'
-export const ERR_SIGNATURE_CREATION = 'ERR_SIGNATURE_CREATION'
-export const ERR_SIGNATURE_VERIFICATION = 'ERR_SIGNATURE_VERIFICATION'
-export const ERR_UNRECOGNIZED_FORMAT = 'ERR_UNRECOGNIZED_FORMAT'
-export const ERR_PEER_ID_FROM_PUBLIC_KEY = 'ERR_PEER_ID_FROM_PUBLIC_KEY'
-export const ERR_PUBLIC_KEY_FROM_ID = 'ERR_PUBLIC_KEY_FROM_ID'
-export const ERR_UNDEFINED_PARAMETER = 'ERR_UNDEFINED_PARAMETER'
-export const ERR_INVALID_RECORD_DATA = 'ERR_INVALID_RECORD_DATA'
-export const ERR_INVALID_VALUE = 'ERR_INVALID_VALUE'
-export const ERR_INVALID_EMBEDDED_KEY = 'ERR_INVALID_EMBEDDED_KEY'
-export const ERR_MISSING_PRIVATE_KEY = 'ERR_MISSING_PRIVATE_KEY'
-export const ERR_RECORD_TOO_LARGE = 'ERR_RECORD_TOO_LARGE'
+export class SignatureCreationError extends Error {
+  static name = 'SignatureCreationError'
+
+  constructor (message = 'Record signature creation failed') {
+    super(message)
+    this.name = 'SignatureCreationError'
+  }
+}
+
+export class SignatureVerificationError extends Error {
+  static name = 'SignatureVerificationError'
+
+  constructor (message = 'Record signature verification failed') {
+    super(message)
+    this.name = 'SignatureVerificationError'
+  }
+}
+
+export class RecordExpiredError extends Error {
+  static name = 'RecordExpiredError'
+
+  constructor (message = 'Record has expired') {
+    super(message)
+    this.name = 'RecordExpiredError'
+  }
+}
+
+export class UnsupportedValidityError extends Error {
+  static name = 'UnsupportedValidityError'
+
+  constructor (message = 'The validity type is unsupported') {
+    super(message)
+    this.name = 'UnsupportedValidityError'
+  }
+}
+
+export class RecordTooLargeError extends Error {
+  static name = 'RecordTooLargeError'
+
+  constructor (message = 'The record is too large') {
+    super(message)
+    this.name = 'RecordTooLargeError'
+  }
+}
+
+export class InvalidValueError extends Error {
+  static name = 'InvalidValueError'
+
+  constructor (message = 'Value must be a valid content path starting with /') {
+    super(message)
+    this.name = 'InvalidValueError'
+  }
+}
+
+export class InvalidRecordDataError extends Error {
+  static name = 'InvalidRecordDataError'
+
+  constructor (message = 'Invalid record data') {
+    super(message)
+    this.name = 'InvalidRecordDataError'
+  }
+}
+
+export class InvalidEmbeddedPublicKeyError extends Error {
+  static name = 'InvalidEmbeddedPublicKeyError'
+
+  constructor (message = 'Invalid embedded public key') {
+    super(message)
+    this.name = 'InvalidEmbeddedPublicKeyError'
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,15 @@
-import { unmarshalPrivateKey } from '@libp2p/crypto/keys'
+import { publicKeyToProtobuf } from '@libp2p/crypto/keys'
 import { logger } from '@libp2p/logger'
-import errCode from 'err-code'
-import { Key } from 'interface-datastore/key'
-import { base32upper } from 'multiformats/bases/base32'
-import * as Digest from 'multiformats/hashes/digest'
-import { identity } from 'multiformats/hashes/identity'
+import { type Key } from 'interface-datastore/key'
 import NanoDate from 'timestamp-nano'
-import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import * as ERRORS from './errors.js'
+import { SignatureCreationError } from './errors.js'
 import { IpnsEntry } from './pb/ipns.js'
 import { createCborData, ipnsRecordDataForV1Sig, ipnsRecordDataForV2Sig, normalizeValue } from './utils.js'
-import type { PrivateKey, PeerId } from '@libp2p/interface'
+import type { PrivateKey, PublicKey } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
 
 const log = logger('ipns')
-const ID_MULTIHASH_CODE = identity.code
 const DEFAULT_TTL_NS = 60 * 60 * 1e+9 // 1 Hour or 3600 Seconds
 
 export const namespace = '/ipns/'
@@ -157,22 +151,22 @@ const defaultCreateOptions: CreateOptions = {
  * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${cidV1Libp2pKey}`
  * * String paths will be stored in the record as-is, but they must start with `"/"`
  *
- * @param {PeerId} peerId - peer id containing private key for signing the record.
- * @param {CID | PeerId | string} value - content to be stored in the record.
+ * @param {PrivateKey} privateKey - the private key for signing the record.
+ * @param {CID | PublicKey | string} value - content to be stored in the record.
  * @param {number | bigint} seq - number representing the current version of the record.
  * @param {number} lifetime - lifetime of the record (in milliseconds).
  * @param {CreateOptions} options - additional create options.
  */
-export async function create (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, lifetime: number, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
-export async function create (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, lifetime: number, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function create (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, lifetime: number, options: CreateOptions): Promise<IPNSRecordV1V2>
-export async function create (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, lifetime: number, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options: CreateV2Options): Promise<IPNSRecordV2>
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options: CreateOptions): Promise<IPNSRecordV1V2>
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
   // Validity in ISOString with nanoseconds precision and validity type EOL
   const expirationDate = new NanoDate(Date.now() + Number(lifetime))
   const validityType = IpnsEntry.ValidityType.EOL
   const ttlNs = BigInt(options.ttlNs ?? DEFAULT_TTL_NS)
 
-  return _create(peerId, value, seq, validityType, expirationDate.toString(), ttlNs, options)
+  return _create(privateKey, value, seq, validityType, expirationDate.toString(), ttlNs, options)
 }
 
 /**
@@ -185,34 +179,28 @@ export async function create (peerId: PeerId, value: CID | PeerId | string, seq:
  * * PeerIDs will create recursive records, eg. the record value will be `/ipns/${cidV1Libp2pKey}`
  * * String paths will be stored in the record as-is, but they must start with `"/"`
  *
- * @param {PeerId} peerId - PeerId containing private key for signing the record.
- * @param {CID | PeerId | string} value - content to be stored in the record.
+ * @param {PrivateKey} privateKey - the private key for signing the record.
+ * @param {CID | PublicKey | string} value - content to be stored in the record.
  * @param {number | bigint} seq - number representing the current version of the record.
  * @param {string} expiration - expiration datetime for record in the [RFC3339]{@link https://www.ietf.org/rfc/rfc3339.txt} with nanoseconds precision.
  * @param {CreateOptions} options - additional creation options.
  */
-export async function createWithExpiration (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, expiration: string, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
-export async function createWithExpiration (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, expiration: string, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function createWithExpiration (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, expiration: string, options: CreateOptions): Promise<IPNSRecordV1V2>
-export async function createWithExpiration (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, expiration: string, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options: CreateV2Options): Promise<IPNSRecordV2>
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options: CreateOptions): Promise<IPNSRecordV1V2>
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
   const expirationDate = NanoDate.fromString(expiration)
   const validityType = IpnsEntry.ValidityType.EOL
   const ttlNs = BigInt(options.ttlNs ?? DEFAULT_TTL_NS)
 
-  return _create(peerId, value, seq, validityType, expirationDate.toString(), ttlNs, options)
+  return _create(privateKey, value, seq, validityType, expirationDate.toString(), ttlNs, options)
 }
 
-const _create = async (peerId: PeerId, value: CID | PeerId | string, seq: number | bigint, validityType: IpnsEntry.ValidityType, validity: string, ttl: bigint, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> => {
+const _create = async (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, validityType: IpnsEntry.ValidityType, validity: string, ttl: bigint, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> => {
   seq = BigInt(seq)
   const isoValidity = uint8ArrayFromString(validity)
   const normalizedValue = normalizeValue(value)
   const encodedValue = uint8ArrayFromString(normalizedValue)
-
-  if (peerId.privateKey == null) {
-    throw errCode(new Error('Missing private key'), ERRORS.ERR_MISSING_PRIVATE_KEY)
-  }
-
-  const privateKey = await unmarshalPrivateKey(peerId.privateKey)
   const data = createCborData(encodedValue, validityType, isoValidity, seq, ttl)
   const sigData = ipnsRecordDataForV2Sig(data)
   const signatureV2 = await privateKey.sign(sigData)
@@ -220,12 +208,8 @@ const _create = async (peerId: PeerId, value: CID | PeerId | string, seq: number
 
   // if we cannot derive the public key from the PeerId (e.g. RSA PeerIDs),
   // we have to embed it in the IPNS record
-  if (peerId.publicKey != null) {
-    const digest = Digest.decode(peerId.toBytes())
-
-    if (digest.code !== ID_MULTIHASH_CODE || !uint8ArrayEquals(peerId.publicKey, digest.digest)) {
-      pubKey = peerId.publicKey
-    }
+  if (privateKey.type === 'RSA') {
+    pubKey = publicKeyToProtobuf(privateKey.publicKey)
   }
 
   if (options.v1Compatible === true) {
@@ -266,24 +250,13 @@ const _create = async (peerId: PeerId, value: CID | PeerId | string, seq: number
   }
 }
 
-/**
- * rawStdEncoding with RFC4648
- */
-const rawStdEncoding = (key: Uint8Array): string => base32upper.encode(key).slice(1)
-
-/**
- * Get key for storing the record locally.
- * Format: /ipns/${base32(<HASH>)}
- *
- * @param {Uint8Array} key - peer identifier object.
- */
-export const getLocalKey = (key: Uint8Array): Key => new Key(`/ipns/${rawStdEncoding(key)}`)
-
-export { unmarshal } from './utils.js'
-export { marshal } from './utils.js'
-export { peerIdToRoutingKey } from './utils.js'
-export { peerIdFromRoutingKey } from './utils.js'
-export { extractPublicKey } from './utils.js'
+export { unmarshalIPNSRecord } from './utils.js'
+export { marshalIPNSRecord } from './utils.js'
+export { multihashToIPNSRoutingKey } from './utils.js'
+export { multihashFromIPNSRoutingKey } from './utils.js'
+export { publicKeyToIPNSRoutingKey } from './utils.js'
+export { publicKeyFromIPNSRoutingKey } from './utils.js'
+export { extractPublicKeyFromIPNSRecord } from './utils.js'
 
 /**
  * Sign ipns record data using the legacy V1 signature scheme
@@ -295,6 +268,6 @@ const signLegacyV1 = async (privateKey: PrivateKey, value: Uint8Array, validityT
     return await privateKey.sign(dataForSignature)
   } catch (error: any) {
     log.error('record signature creation failed', error)
-    throw errCode(new Error('record signature creation failed'), ERRORS.ERR_SIGNATURE_CREATION)
+    throw new SignatureCreationError('Record signature creation failed')
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { IpnsEntry } from './pb/ipns.js'
 import { createCborData, ipnsRecordDataForV1Sig, ipnsRecordDataForV2Sig, normalizeValue } from './utils.js'
 import type { PrivateKey, PublicKey } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
+import type { MultihashDigest } from 'multiformats/hashes/interface'
 
 const log = logger('ipns')
 const DEFAULT_TTL_NS = 60 * 60 * 1e+9 // 1 Hour or 3600 Seconds
@@ -157,10 +158,10 @@ const defaultCreateOptions: CreateOptions = {
  * @param {number} lifetime - lifetime of the record (in milliseconds).
  * @param {CreateOptions} options - additional create options.
  */
-export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
-export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options: CreateOptions): Promise<IPNSRecordV1V2>
-export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, lifetime: number, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, lifetime: number, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, lifetime: number, options: CreateV2Options): Promise<IPNSRecordV2>
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, lifetime: number, options: CreateOptions): Promise<IPNSRecordV1V2>
+export async function createIPNSRecord (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, lifetime: number, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
   // Validity in ISOString with nanoseconds precision and validity type EOL
   const expirationDate = new NanoDate(Date.now() + Number(lifetime))
   const validityType = IpnsEntry.ValidityType.EOL
@@ -185,10 +186,10 @@ export async function createIPNSRecord (privateKey: PrivateKey, value: CID | Pub
  * @param {string} expiration - expiration datetime for record in the [RFC3339]{@link https://www.ietf.org/rfc/rfc3339.txt} with nanoseconds precision.
  * @param {CreateOptions} options - additional creation options.
  */
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options: CreateOptions): Promise<IPNSRecordV1V2>
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, expiration: string, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, expiration: string, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, expiration: string, options: CreateV2Options): Promise<IPNSRecordV2>
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, expiration: string, options: CreateOptions): Promise<IPNSRecordV1V2>
+export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, expiration: string, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
   const expirationDate = NanoDate.fromString(expiration)
   const validityType = IpnsEntry.ValidityType.EOL
   const ttlNs = BigInt(options.ttlNs ?? DEFAULT_TTL_NS)
@@ -196,7 +197,7 @@ export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, va
   return _create(privateKey, value, seq, validityType, expirationDate.toString(), ttlNs, options)
 }
 
-const _create = async (privateKey: PrivateKey, value: CID | PublicKey | string, seq: number | bigint, validityType: IpnsEntry.ValidityType, validity: string, ttl: bigint, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> => {
+const _create = async (privateKey: PrivateKey, value: CID | PublicKey | MultihashDigest<0x00 | 0x12> | string, seq: number | bigint, validityType: IpnsEntry.ValidityType, validity: string, ttl: bigint, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> => {
   seq = BigInt(seq)
   const isoValidity = uint8ArrayFromString(validity)
   const normalizedValue = normalizeValue(value)
@@ -254,8 +255,6 @@ export { unmarshalIPNSRecord } from './utils.js'
 export { marshalIPNSRecord } from './utils.js'
 export { multihashToIPNSRoutingKey } from './utils.js'
 export { multihashFromIPNSRoutingKey } from './utils.js'
-export { publicKeyToIPNSRoutingKey } from './utils.js'
-export { publicKeyFromIPNSRoutingKey } from './utils.js'
 export { extractPublicKeyFromIPNSRecord } from './utils.js'
 
 /**

--- a/src/pb/ipns.ts
+++ b/src/pb/ipns.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, type DecodeOptions, encodeMessage, enumeration, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface IpnsEntry {
@@ -92,7 +91,7 @@ export namespace IpnsEntry {
         if (opts.lengthDelimited !== false) {
           w.ldelim()
         }
-      }, (reader, length) => {
+      }, (reader, length, opts = {}) => {
         const obj: any = {}
 
         const end = length == null ? reader.len : reader.pos + length
@@ -101,36 +100,46 @@ export namespace IpnsEntry {
           const tag = reader.uint32()
 
           switch (tag >>> 3) {
-            case 1:
+            case 1: {
               obj.value = reader.bytes()
               break
-            case 2:
+            }
+            case 2: {
               obj.signatureV1 = reader.bytes()
               break
-            case 3:
+            }
+            case 3: {
               obj.validityType = IpnsEntry.ValidityType.codec().decode(reader)
               break
-            case 4:
+            }
+            case 4: {
               obj.validity = reader.bytes()
               break
-            case 5:
+            }
+            case 5: {
               obj.sequence = reader.uint64()
               break
-            case 6:
+            }
+            case 6: {
               obj.ttl = reader.uint64()
               break
-            case 7:
+            }
+            case 7: {
               obj.pubKey = reader.bytes()
               break
-            case 8:
+            }
+            case 8: {
               obj.signatureV2 = reader.bytes()
               break
-            case 9:
+            }
+            case 9: {
               obj.data = reader.bytes()
               break
-            default:
+            }
+            default: {
               reader.skipType(tag & 7)
               break
+            }
           }
         }
 
@@ -145,7 +154,7 @@ export namespace IpnsEntry {
     return encodeMessage(obj, IpnsEntry.codec())
   }
 
-  export const decode = (buf: Uint8Array | Uint8ArrayList): IpnsEntry => {
-    return decodeMessage(buf, IpnsEntry.codec())
+  export const decode = (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<IpnsEntry>): IpnsEntry => {
+    return decodeMessage(buf, IpnsEntry.codec(), opts)
   }
 }

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -1,10 +1,10 @@
 import NanoDate from 'timestamp-nano'
 import { IpnsEntry } from './pb/ipns.js'
-import { unmarshal } from './utils.js'
+import { unmarshalIPNSRecord } from './utils.js'
 
 export function ipnsSelector (key: Uint8Array, data: Uint8Array[]): number {
   const entries = data.map((buf, index) => ({
-    record: unmarshal(buf),
+    record: unmarshalIPNSRecord(buf),
     index
   }))
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,7 +139,7 @@ export const publicKeyToIPNSRoutingKey = (publicKey: PublicKey): Uint8Array => {
   return multihashToIPNSRoutingKey(publicKey.toMultihash())
 }
 
-export const multihashToIPNSRoutingKey = (digest: MultihashDigest): Uint8Array => {
+export const multihashToIPNSRoutingKey = (digest: MultihashDigest<0x00 | 0x12>): Uint8Array => {
   return uint8ArrayConcat([
     IPNS_PREFIX,
     digest.bytes
@@ -153,7 +153,7 @@ export const publicKeyFromIPNSRoutingKey = (key: Uint8Array): Ed25519PublicKey |
   } catch {}
 }
 
-export const multihashFromIPNSRoutingKey = (key: Uint8Array): MultihashDigest<0x00> | MultihashDigest<0x12> => {
+export const multihashFromIPNSRoutingKey = (key: Uint8Array): MultihashDigest<0x00 | 0x12> => {
   const digest = Digest.decode(key.slice(IPNS_PREFIX.length))
 
   if (digest.code !== 0x00 && digest.code !== 0x12) {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,9 +1,9 @@
 import { logger } from '@libp2p/logger'
-import errCode from 'err-code'
 import NanoDate from 'timestamp-nano'
-import * as ERRORS from './errors.js'
+import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
+import { InvalidEmbeddedPublicKeyError, RecordExpiredError, RecordTooLargeError, SignatureVerificationError, UnsupportedValidityError } from './errors.js'
 import { IpnsEntry } from './pb/ipns.js'
-import { extractPublicKey, ipnsRecordDataForV2Sig, unmarshal, peerIdFromRoutingKey } from './utils.js'
+import { extractPublicKeyFromIPNSRecord, ipnsRecordDataForV2Sig, publicKeyFromIPNSRoutingKey, publicKeyToIPNSRoutingKey, unmarshalIPNSRecord } from './utils.js'
 import type { PublicKey } from '@libp2p/interface'
 
 const log = logger('ipns:validator')
@@ -21,30 +21,32 @@ export const validate = async (publicKey: PublicKey, buf: Uint8Array): Promise<v
   // unmarshal ensures that (1) SignatureV2 and Data are present, (2) that ValidityType
   // and Validity are of valid types and have a value, (3) that CBOR data matches protobuf
   // if it's a V1+V2 record.
-  const record = unmarshal(buf)
+  const record = unmarshalIPNSRecord(buf)
 
   // Validate Signature V2
   let isValid
+
   try {
     const dataForSignature = ipnsRecordDataForV2Sig(record.data)
     isValid = await publicKey.verify(dataForSignature, record.signatureV2)
   } catch (err) {
     isValid = false
   }
+
   if (!isValid) {
     log.error('record signature verification failed')
-    throw errCode(new Error('record signature verification failed'), ERRORS.ERR_SIGNATURE_VERIFICATION)
+    throw new SignatureVerificationError('Record signature verification failed')
   }
 
   // Validate according to the validity type
   if (record.validityType === IpnsEntry.ValidityType.EOL) {
     if (NanoDate.fromString(record.validity).toDate().getTime() < Date.now()) {
       log.error('record has expired')
-      throw errCode(new Error('record has expired'), ERRORS.ERR_IPNS_EXPIRED_RECORD)
+      throw new RecordExpiredError('record has expired')
     }
   } else if (record.validityType != null) {
-    log.error('unrecognized validity type')
-    throw errCode(new Error('unrecognized validity type'), ERRORS.ERR_UNRECOGNIZED_VALIDITY)
+    log.error('the validity type is unsupported')
+    throw new UnsupportedValidityError('The validity type is unsupported')
   }
 
   log('ipns record for %s is valid', record.value)
@@ -52,15 +54,26 @@ export const validate = async (publicKey: PublicKey, buf: Uint8Array): Promise<v
 
 export async function ipnsValidator (key: Uint8Array, marshalledData: Uint8Array): Promise<void> {
   if (marshalledData.byteLength > MAX_RECORD_SIZE) {
-    throw errCode(new Error('record too large'), ERRORS.ERR_RECORD_TOO_LARGE)
+    throw new RecordTooLargeError('The record is too large')
   }
 
-  const peerId = peerIdFromRoutingKey(key)
-  const receivedRecord = unmarshal(marshalledData)
+  // try to extract public key from routing key
+  const routingPubKey = publicKeyFromIPNSRoutingKey(key)
 
-  // extract public key
-  const pubKey = await extractPublicKey(peerId, receivedRecord)
+  // extract public key from record
+  const receivedRecord = unmarshalIPNSRecord(marshalledData)
+  const recordPubKey = extractPublicKeyFromIPNSRecord(receivedRecord) ?? routingPubKey
+
+  if (recordPubKey == null) {
+    throw new InvalidEmbeddedPublicKeyError('Could not extract public key from IPNS record or routing key')
+  }
+
+  const routingKey = publicKeyToIPNSRoutingKey(recordPubKey)
+
+  if (!uint8ArrayEquals(key, routingKey)) {
+    throw new InvalidEmbeddedPublicKeyError('Embedded public key did not match routing key')
+  }
 
   // Record validation
-  await validate(pubKey, marshalledData)
+  await validate(recordPubKey, marshalledData)
 }

--- a/test/conformance.spec.ts
+++ b/test/conformance.spec.ts
@@ -1,30 +1,34 @@
 /* eslint-env mocha */
 
-import { unmarshalPublicKey } from '@libp2p/crypto/keys'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import loadFixture from 'aegir/fixtures'
 import { base36 } from 'multiformats/bases/base36'
 import { CID } from 'multiformats/cid'
-import * as ERRORS from '../src/errors.js'
-import * as ipns from '../src/index.js'
+import { SignatureVerificationError } from '../src/errors.js'
+import { marshalIPNSRecord, unmarshalIPNSRecord } from '../src/index.js'
 import { validate } from '../src/validator.js'
 
 describe('conformance', function () {
   it('should reject a v1 only record', async () => {
     const buf = loadFixture('test/fixtures/k51qzi5uqu5dm4tm0wt8srkg9h9suud4wuiwjimndrkydqm81cqtlb5ak6p7ku_v1.ipns-record')
 
-    expect(() => ipns.unmarshal(buf)).to.throw(/missing data or signatureV2/)
-      .with.property('code', ERRORS.ERR_SIGNATURE_VERIFICATION)
+    expect(() => unmarshalIPNSRecord(buf)).to.throw(/Missing data or signatureV2/)
+      .with.property('name', SignatureVerificationError.name)
   })
 
   it('should validate a record with v1 and v2 signatures', async () => {
     const buf = loadFixture('test/fixtures/k51qzi5uqu5dlkw8pxuw9qmqayfdeh4kfebhmreauqdc6a7c3y7d5i9fi8mk9w_v1-v2.ipns-record')
-    const record = ipns.unmarshal(buf)
+    const record = unmarshalIPNSRecord(buf)
 
     const cid = CID.parse('k51qzi5uqu5dlkw8pxuw9qmqayfdeh4kfebhmreauqdc6a7c3y7d5i9fi8mk9w', base36)
     const peerId = peerIdFromCID(cid)
-    const publicKey = unmarshalPublicKey(peerId.publicKey ?? new Uint8Array())
+
+    if (peerId.publicKey == null) {
+      throw new Error('Peer ID embedded in CID had no public key')
+    }
+
+    const publicKey = peerId.publicKey
     await validate(publicKey, buf)
 
     expect(record.value).to.equal('/ipfs/bafkqaddwgevxmmraojswg33smq')
@@ -33,34 +37,44 @@ describe('conformance', function () {
   it('should reject a record with inconsistent value fields', async () => {
     const buf = loadFixture('test/fixtures/k51qzi5uqu5dlmit2tuwdvnx4sbnyqgmvbxftl0eo3f33wwtb9gr7yozae9kpw_v1-v2-broken-v1-value.ipns-record')
 
-    expect(() => ipns.unmarshal(buf)).to.throw(/Field "value" did not match/)
-      .with.property('code', ERRORS.ERR_SIGNATURE_VERIFICATION)
+    expect(() => unmarshalIPNSRecord(buf)).to.throw(/Field "value" did not match/)
+      .with.property('name', SignatureVerificationError.name)
   })
 
   it('should reject a record with v1 and v2 signatures but invalid v2', async () => {
     const buf = loadFixture('test/fixtures/k51qzi5uqu5diamp7qnnvs1p1gzmku3eijkeijs3418j23j077zrkok63xdm8c_v1-v2-broken-signature-v2.ipns-record')
     const cid = CID.parse('k51qzi5uqu5diamp7qnnvs1p1gzmku3eijkeijs3418j23j077zrkok63xdm8c', base36)
     const peerId = peerIdFromCID(cid)
-    const publicKey = unmarshalPublicKey(peerId.publicKey ?? new Uint8Array())
 
-    await expect(validate(publicKey, buf)).to.eventually.be.rejectedWith(/record signature verification failed/)
-      .with.property('code', ERRORS.ERR_SIGNATURE_VERIFICATION)
+    if (peerId.publicKey == null) {
+      throw new Error('Peer ID embedded in CID had no public key')
+    }
+
+    const publicKey = peerId.publicKey
+
+    await expect(validate(publicKey, buf)).to.eventually.be.rejectedWith(/Record signature verification failed/)
+      .with.property('name', SignatureVerificationError.name)
   })
 
   it('should reject a record with v1 and v2 signatures but invalid v1', async () => {
     const buf = loadFixture('test/fixtures/k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y_v1-v2-broken-signature-v1.ipns-record')
-    const record = ipns.unmarshal(buf)
+    const record = unmarshalIPNSRecord(buf)
 
     expect(record.value).to.equal('/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi')
   })
 
   it('should validate a record with only v2 signature', async () => {
     const buf = loadFixture('test/fixtures/k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f_v2.ipns-record')
-    const record = ipns.unmarshal(buf)
+    const record = unmarshalIPNSRecord(buf)
 
     const cid = CID.parse('k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f', base36)
     const peerId = peerIdFromCID(cid)
-    const publicKey = unmarshalPublicKey(peerId.publicKey ?? new Uint8Array())
+
+    if (peerId.publicKey == null) {
+      throw new Error('Peer ID embedded in CID had no public key')
+    }
+
+    const publicKey = peerId.publicKey
     await validate(publicKey, buf)
 
     expect(record.value).to.equal('/ipfs/bafkqadtwgiww63tmpeqhezldn5zgi')
@@ -76,8 +90,8 @@ describe('conformance', function () {
 
     for (const fixture of fixtures) {
       const buf = loadFixture(fixture)
-      const record = ipns.unmarshal(buf)
-      const marshalled = ipns.marshal(record)
+      const record = unmarshalIPNSRecord(buf)
+      const marshalled = marshalIPNSRecord(record)
 
       expect(buf).to.equalBytes(marshalled)
     }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -356,6 +356,7 @@ describe('ipns', function () {
 
     keys.forEach(key => {
       const digest = Digest.decode(base58btc.decode(`z${key}`))
+      // @ts-expect-error digest may have the wrong hash type
       const routingKey = multihashToIPNSRoutingKey(digest)
       const id = multihashFromIPNSRoutingKey(routingKey)
 

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -2,7 +2,7 @@
 
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { expect } from 'aegir/chai'
-import { createIPNSRecord, marshalIPNSRecord, publicKeyToIPNSRoutingKey } from '../src/index.js'
+import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey } from '../src/index.js'
 import { ipnsSelector } from '../src/selector.js'
 import type { PrivateKey } from '@libp2p/interface'
 
@@ -26,7 +26,7 @@ describe('selector', function () {
     const marshalledData = marshalIPNSRecord(record)
     const marshalledNewData = marshalIPNSRecord(newRecord)
 
-    const key = publicKeyToIPNSRoutingKey(privateKey.publicKey)
+    const key = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
 
     let valid = ipnsSelector(key, [marshalledNewData, marshalledData])
     expect(valid).to.equal(0) // new data is the selected one
@@ -45,7 +45,7 @@ describe('selector', function () {
     const marshalledData = marshalIPNSRecord(record)
     const marshalledNewData = marshalIPNSRecord(newRecord)
 
-    const key = publicKeyToIPNSRoutingKey(privateKey.publicKey)
+    const key = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
 
     let valid = ipnsSelector(key, [marshalledNewData, marshalledData])
     expect(valid).to.equal(0) // new data is the selected one

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -2,7 +2,7 @@ import { peerIdFromString } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
 import { CID } from 'multiformats/cid'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { normalizeValue, peerIdFromRoutingKey, peerIdToRoutingKey } from '../src/utils.js'
+import { normalizeValue, multihashFromIPNSRoutingKey, multihashToIPNSRoutingKey, normalizeByteValue } from '../src/utils.js'
 import type { PeerId } from '@libp2p/interface'
 
 describe('utils', () => {
@@ -40,8 +40,18 @@ describe('utils', () => {
       'string path': {
         input: '/hello',
         output: '/hello'
-      },
+      }
+    }
 
+    Object.entries(cases).forEach(([name, { input, output }]) => {
+      it(`should normalize a ${name}`, async () => {
+        expect(normalizeValue(await input)).to.equal(output)
+      })
+    })
+  })
+
+  describe('normalizeByteValue', () => {
+    const cases: Record<string, { input: Uint8Array, output: string }> = {
       // Uint8Array input
       'v0 CID bytes': {
         input: CID.parse('QmWEekX7EZLUd9VXRNMRXW3LXe4F6x7mB8oPxY5XLptrBq').bytes,
@@ -74,8 +84,8 @@ describe('utils', () => {
     }
 
     Object.entries(cases).forEach(([name, { input, output }]) => {
-      it(`should normalize a ${name}`, async () => {
-        expect(normalizeValue(await input)).to.equal(output)
+      it(`should normalize a ${name}`, () => {
+        expect(normalizeByteValue(input)).to.equal(output)
       })
     })
   })
@@ -89,10 +99,10 @@ describe('utils', () => {
 
     Object.entries(cases).forEach(([name, input]) => {
       it(`should round trip a ${name} key`, async () => {
-        const key = peerIdToRoutingKey(input)
-        const output = peerIdFromRoutingKey(key)
+        const key = multihashToIPNSRoutingKey(input.toMultihash())
+        const output = multihashFromIPNSRoutingKey(key)
 
-        expect(input.equals(output)).to.be.true()
+        expect(input.toMultihash().bytes).to.equalBytes(output.bytes)
       })
     })
   })

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -1,43 +1,32 @@
 /* eslint-env mocha */
 
 import { randomBytes } from '@libp2p/crypto'
-import { generateKeyPair } from '@libp2p/crypto/keys'
-import { peerIdFromKeys } from '@libp2p/peer-id'
+import { generateKeyPair, publicKeyToProtobuf } from '@libp2p/crypto/keys'
 import { expect } from 'aegir/chai'
-import { base58btc } from 'multiformats/bases/base58'
-import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import * as ERRORS from '../src/errors.js'
-import * as ipns from '../src/index.js'
-import { marshal, peerIdToRoutingKey } from '../src/utils.js'
+import { InvalidEmbeddedPublicKeyError, RecordTooLargeError, SignatureVerificationError } from '../src/errors.js'
+import { createIPNSRecord, marshalIPNSRecord, publicKeyToIPNSRoutingKey } from '../src/index.js'
 import { ipnsValidator } from '../src/validator.js'
-import type { PeerId } from '@libp2p/interface'
+import type { PrivateKey } from '@libp2p/interface'
 
 describe('validator', function () {
   this.timeout(20 * 1000)
 
   const contentPath = '/ipfs/bafkqae3imvwgy3zamzzg63janjzs22lqnzzqu'
-  let peerId1: PeerId
-  let peerId2: PeerId
+  let privateKey1: PrivateKey
+  let privateKey2: PrivateKey
 
   before(async () => {
-    const rsa = await generateKeyPair('RSA', 2048)
-    peerId1 = await peerIdFromKeys(rsa.public.bytes, rsa.bytes)
-
-    const rsa2 = await generateKeyPair('RSA', 2048)
-    peerId2 = await peerIdFromKeys(rsa2.public.bytes, rsa2.bytes)
+    privateKey1 = await generateKeyPair('RSA', 2048)
+    privateKey2 = await generateKeyPair('RSA', 2048)
   })
 
   it('should validate a (V2) record', async () => {
     const sequence = 0
     const validity = 1000000
-
-    const record = await ipns.create(peerId1, contentPath, sequence, validity, { v1Compatible: false })
-    const marshalledData = marshal(record)
-
-    const keyBytes = base58btc.decode(`z${peerId1.toString()}`)
-    const key = uint8ArrayConcat([uint8ArrayFromString('/ipns/'), keyBytes])
+    const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity, { v1Compatible: false })
+    const marshalledData = marshalIPNSRecord(record)
+    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
 
     await ipnsValidator(key, marshalledData)
   })
@@ -45,12 +34,9 @@ describe('validator', function () {
   it('should validate a (V1+V2) record', async () => {
     const sequence = 0
     const validity = 1000000
-
-    const record = await ipns.create(peerId1, contentPath, sequence, validity, { v1Compatible: true })
-    const marshalledData = marshal(record)
-
-    const keyBytes = base58btc.decode(`z${peerId1.toString()}`)
-    const key = uint8ArrayConcat([uint8ArrayFromString('/ipns/'), keyBytes])
+    const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity, { v1Compatible: true })
+    const marshalledData = marshalIPNSRecord(record)
+    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
 
     await ipnsValidator(key, marshalledData)
   })
@@ -59,46 +45,50 @@ describe('validator', function () {
     const sequence = 0
     const validity = 1000000
 
-    const record = await ipns.create(peerId1, contentPath, sequence, validity)
+    const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity)
 
     // corrupt the record by changing the value to random bytes
     record.value = uint8ArrayToString(randomBytes(record.value?.length ?? 0))
-    const marshalledData = marshal(record)
+    const marshalledData = marshalIPNSRecord(record)
 
-    const key = peerIdToRoutingKey(peerId1)
+    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
 
-    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected().with.property('code', ERRORS.ERR_SIGNATURE_VERIFICATION)
+    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected()
+      .with.property('name', SignatureVerificationError.name)
   })
 
   it('should use validator.validate to verify that a record is not valid when it is passed with the wrong IPNS key', async () => {
     const sequence = 0
     const validity = 1000000
 
-    const record = await ipns.create(peerId1, contentPath, sequence, validity)
-    const marshalledData = marshal(record)
+    const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity)
+    const marshalledData = marshalIPNSRecord(record)
 
-    const key = peerIdToRoutingKey(peerId2)
+    const key = publicKeyToIPNSRoutingKey(privateKey2.publicKey)
 
-    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected().with.property('code', ERRORS.ERR_INVALID_EMBEDDED_KEY)
+    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected()
+      .with.property('name', InvalidEmbeddedPublicKeyError.name)
   })
 
   it('should use validator.validate to verify that a record is not valid when the wrong key is embedded', async () => {
     const sequence = 0
     const validity = 1000000
 
-    const record = await ipns.create(peerId1, contentPath, sequence, validity)
-    record.pubKey = peerId2.publicKey
-    const marshalledData = marshal(record)
+    const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity)
+    record.pubKey = publicKeyToProtobuf(privateKey2.publicKey)
+    const marshalledData = marshalIPNSRecord(record)
 
-    const key = peerIdToRoutingKey(peerId1)
+    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
 
-    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected().with.property('code', ERRORS.ERR_INVALID_EMBEDDED_KEY)
+    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected()
+      .with.property('name', InvalidEmbeddedPublicKeyError.name)
   })
 
   it('should limit the size of incoming records', async () => {
     const marshalledData = new Uint8Array(1024 * 1024)
     const key = new Uint8Array()
 
-    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected().with.property('code', ERRORS.ERR_RECORD_TOO_LARGE)
+    await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected()
+      .with.property('name', RecordTooLargeError.name)
   })
 })

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -5,7 +5,7 @@ import { generateKeyPair, publicKeyToProtobuf } from '@libp2p/crypto/keys'
 import { expect } from 'aegir/chai'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { InvalidEmbeddedPublicKeyError, RecordTooLargeError, SignatureVerificationError } from '../src/errors.js'
-import { createIPNSRecord, marshalIPNSRecord, publicKeyToIPNSRoutingKey } from '../src/index.js'
+import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey } from '../src/index.js'
 import { ipnsValidator } from '../src/validator.js'
 import type { PrivateKey } from '@libp2p/interface'
 
@@ -26,7 +26,7 @@ describe('validator', function () {
     const validity = 1000000
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity, { v1Compatible: false })
     const marshalledData = marshalIPNSRecord(record)
-    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
+    const key = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
 
     await ipnsValidator(key, marshalledData)
   })
@@ -36,7 +36,7 @@ describe('validator', function () {
     const validity = 1000000
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity, { v1Compatible: true })
     const marshalledData = marshalIPNSRecord(record)
-    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
+    const key = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
 
     await ipnsValidator(key, marshalledData)
   })
@@ -51,7 +51,7 @@ describe('validator', function () {
     record.value = uint8ArrayToString(randomBytes(record.value?.length ?? 0))
     const marshalledData = marshalIPNSRecord(record)
 
-    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
+    const key = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
 
     await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected()
       .with.property('name', SignatureVerificationError.name)
@@ -64,7 +64,7 @@ describe('validator', function () {
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity)
     const marshalledData = marshalIPNSRecord(record)
 
-    const key = publicKeyToIPNSRoutingKey(privateKey2.publicKey)
+    const key = multihashToIPNSRoutingKey(privateKey2.publicKey.toMultihash())
 
     await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected()
       .with.property('name', InvalidEmbeddedPublicKeyError.name)
@@ -78,7 +78,7 @@ describe('validator', function () {
     record.pubKey = publicKeyToProtobuf(privateKey2.publicKey)
     const marshalledData = marshalIPNSRecord(record)
 
-    const key = publicKeyToIPNSRoutingKey(privateKey1.publicKey)
+    const key = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
 
     await expect(ipnsValidator(key, marshalledData)).to.eventually.be.rejected()
       .with.property('name', InvalidEmbeddedPublicKeyError.name)


### PR DESCRIPTION
- Updates method names so they can be invidually imported but still be legible
- Operates on PrivateKey/PublicKeys instead of PeerIds to integrate with the libp2p@2.x.x keychain will less friction

BREAKING CHANGE: uses libp2p@2.x.x deps, operates on PrivateKey/PublicKeys instead of PeerIds